### PR TITLE
feat(options): auto reload open dev.azure.com/* tabs after saving new jiraBaseUrl at options page

### DIFF
--- a/src/manifest_template.json
+++ b/src/manifest_template.json
@@ -18,7 +18,7 @@
     "page": "options/options.html",
     "open_in_tab": true
   },
-  "permissions": ["storage"],
+  "permissions": ["storage", "https://dev.azure.com/*"],
   "browser_specific_settings": {
     "gecko": {
       "id": "addon@example.com"

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -1,4 +1,5 @@
-import browser from "webextension-polyfill";
+import browser, { Tabs } from "webextension-polyfill";
+import Tab = Tabs.Tab;
 
 export async function saveOptions(e: Event) {
   e.preventDefault();
@@ -15,7 +16,15 @@ export async function saveOptions(e: Event) {
   if (successMessageDiv) {
     successMessageDiv.removeAttribute("hidden");
     successMessageDiv.innerText = `Saved ${jiraBaseUrl}`;
+    await refreshAzureDevopsTabs();
   }
+}
+
+async function refreshAzureDevopsTabs() {
+  const tabs = await browser.tabs.query({ url: "https://dev.azure.com/*" });
+  tabs
+    .map((tab: Tab) => tab.id)
+    .forEach((id: number | undefined) => browser.tabs.reload(id));
 }
 
 export function createDummyJiraLinkFromInput() {

--- a/tests/options/options.spec.ts
+++ b/tests/options/options.spec.ts
@@ -16,8 +16,14 @@ describe("Options", () => {
 
   describe("saveOptions()", () => {
     it("should save it to storage and notify user about successful saving", async () => {
+      const tabs: any[] = [{ id: 1 }, { id: 3 }];
+      mockBrowser.tabs.query
+        .expect({ url: "https://dev.azure.com/*" })
+        .andResolve(tabs);
       document.querySelector("input")!!.value = "aaaaa";
       mockBrowser.storage.sync.set.expect({ jiraBaseUrl: "aaaaa/" });
+      mockBrowser.tabs.reload.expect(1);
+      mockBrowser.tabs.reload.expect(3);
 
       await saveOptions(new Event("does not matter"));
 


### PR DESCRIPTION
Saving new jiraBaseUrl in options page automatically refresh dev.azure.com tabs to change take
effect.
base on:
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/query
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions

fix #8